### PR TITLE
Rename type to templateNamespace

### DIFF
--- a/src/piechart.js
+++ b/src/piechart.js
@@ -78,7 +78,7 @@ angular.module('piechart', [])
       restrict: 'EA',
       require: '^piechart',
       replace: true,
-      type: 'svg',
+      templateNamespace: 'svg',
       template:
         '<path ng-attr-d="M0,0L{{arc.start.x}},{{arc.start.y}}A1,1,1,{{arc.large ? 1 : 0}},1,{{arc.end.x}},{{arc.end.y}}Z" />',
       scope: {


### PR DESCRIPTION
The `type` directive attribute appears to have been renamed to `templateNamespace`. See my SO question for details: http://stackoverflow.com/questions/26963733/what-does-the-type-attribute-of-a-directive-do
